### PR TITLE
minor css fix

### DIFF
--- a/book/css/style.css
+++ b/book/css/style.css
@@ -129,3 +129,7 @@ padding:1em 1em 1em 3em;
 .subitem{
  margin-left:25px;	
 }
+
+#references-list {
+	word-wrap: break-word;
+}

--- a/book/index.html
+++ b/book/index.html
@@ -5753,7 +5753,7 @@ When releasing a plugin, estimate how much time you’ll have to devote to maint
 <p>&nbsp;</p>
 <h1 id="references"><span id="internal-source-marker_0.05095413855216446">References</span><br>
 </h1>
-<ol>
+<ol id="references-list">
   <li>Design Principles and Design Patterns - Robert C Martin<a href="http://www.objectmentor.com/resources/articles/Principles_and_Patterns.pdf">http://www.objectmentor.com/resources/articles/Principles_and_Patterns.pdf</a></li>
   <li>Ralph Johnson - Special Issue of ACM On Patterns and Pattern Languages - <a href="http://www.cs.wustl.edu/%7Eschmidt/CACM-editorial.html">http://www.cs.wustl.edu/~schmidt/CACM-editorial.html</a></li>
   <li>Hillside Engineering Design Patterns Library - <a href="http://hillside.net/patterns/">http://hillside.net/patterns/</a></li>


### PR DESCRIPTION
add css break-word to references list to avoid horizon scrolling when
browser size is not so wide
