### PR TITLE
Small fixes in pub/sub examples

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -2203,18 +2203,17 @@ It's left up to the subscribers to those topics to then delegate what happens wi
 <pre  class="brush: js">
 ;(function( $ ) {
 
+  // Pre-compile templates and "cache" them using closure
+  var 
+    userTemplate = _.template($( "#userTemplate" ).html());
+    ratingTemplate = _.template($( "#ratingsTemplate" ).html());
+	
   // Subscribe to the new user topic, which adds a user
   // to a list of users who have submitted reviews
   $.subscribe( "/new/user", function( e, data ){
 
-    var compiledTemplate;
-
     if( data ){
-
-       compiledTemplate = _.template($( "#userTemplate" ).html());
-
-       $('#users').append( compiledTemplate( data ));
-
+       $('#users').append( userTemplate( data ));
     }
 
   });
@@ -2224,14 +2223,8 @@ It's left up to the subscribers to those topics to then delegate what happens wi
   // ratings.
   $.subscribe( "/new/rating", function( e, data ){
 
-    var compiledTemplate;
-
-    if( data ){
-      
-      compiledTemplate = _.template($( "#ratingsTemplate" ).html());
-
-      $( "#ratings" ).append( compiledTemplate( data );
-
+    if( data ){      
+      $( "#ratings" ).append( ratingTemplate( data );
     }
 
   });
@@ -2307,6 +2300,9 @@ Notice how in our sample below, one topic notification is made when a user indic
 
 ;(function( $ ) {
 
+   // Pre-compile template and "cache" it using closure
+   var resultTemplate = _.template($( "#resultTemplate" ).html());
+
    // Subscribe to the new search tags topic
    $.subscribe( "/search/tags" , function( tags ) {
        $( "#searchResults" )
@@ -2316,9 +2312,7 @@ Notice how in our sample below, one topic notification is made when a user indic
    // Subscribe to the new results topic
    $.subscribe( "/search/resultSet" , function( results ){
 
-       var compiled_template = _.template($( "#resultTemplate" ).html());
-
-       $( "#searchResults" ).append(compiled_template( results ));
+       $( "#searchResults" ).append(resultTemplate( results ));
 
    });
 


### PR DESCRIPTION
- I've fixed a small typo which was introduced in 1.5.2 (it was correct in 1.5.1.)
- I've moved calls to underscore templates out of event handlers to cache template objects

Thanks for this book (and all others), it's awesome!
