### PR TITLE
Pub/sub typo fix, templates cached

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -2036,7 +2036,7 @@ var messageLogger = function ( topics, data ) {
 // Subscribers listen for topics they have subscribed to and
 // invoke a callback function (e.g messageLogger) once a new 
 // notification is broadcast on that topic
-var subscriber = pubsub.subscribe( "inbox/newMessage", messageLogger );
+var subscription = pubsub.subscribe( "inbox/newMessage", messageLogger );
 
 // Publishers are in charge of publishing topics or notifications of
 // interest to the application. e.g:
@@ -2054,7 +2054,7 @@ pubsub.publish( "inbox/newMessage", {
 
 // We cab also unsubscribe if we no longer wish for our subscribers
 // to be notified
-// pubsub.unsubscribe( testSubscription );
+// pubsub.unsubscribe( subscription );
 
 // Once unsubscribed, this for example won't result in our
 // messageLogger being executed as the subscriber is
@@ -2217,13 +2217,14 @@ It's left up to the subscribers to those topics to then delegate what happens wi
   // to a list of users who have submitted reviews
   $.subscribe( "/new/user", function( e, data ){
 
-    var compiledTemplate;
+    // Pre-compile templates and "cache" them using closure
+    var
+      userTemplate = _.template($( "#userTemplate" ).html()),
+      ratingTemplate = _.template($( "#ratingsTemplate" ).html());
 
     if( data ){
 
-       compiledTemplate = _.template($( "#userTemplate" ).html());
-
-       $('#users').append( compiledTemplate( data ));
+      $('#users').append( userTemplate( data ));
 
     }
 
@@ -2238,9 +2239,7 @@ It's left up to the subscribers to those topics to then delegate what happens wi
 
     if( data ){
       
-      compiledTemplate = _.template($( "#ratingsTemplate" ).html());
-
-      $( "#ratings" ).append( compiledTemplate( data ) );
+      $( "#ratings" ).append( ratingTemplate( data );
 
     }
 
@@ -2318,6 +2317,9 @@ Notice how in our sample below, one topic notification is made when a user indic
 
 ;(function( $ ) {
 
+   // Pre-compile template and "cache" it using closure
+   var resultTemplate = _.template($( "#resultTemplate" ).html());
+
    // Subscribe to the new search tags topic
    $.subscribe( "/search/tags" , function( tags ) {
        $( "#searchResults" )
@@ -2327,9 +2329,7 @@ Notice how in our sample below, one topic notification is made when a user indic
    // Subscribe to the new results topic
    $.subscribe( "/search/resultSet" , function( results ){
 
-       var compiled_template = _.template($( "#resultTemplate" ).html());
-
-       $( "#searchResults" ).append(compiled_template( results ));
+       $( "#searchResults" ).append(resultTemplate( results ));
 
    });
 


### PR DESCRIPTION
- Pre-compile underscore templates in pub/sub examples
- Fixing typo in pub/sub example
