### PR TITLE
Allow CareFactory fallback to default vehicleType

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -3034,10 +3034,14 @@ VehicleFactory.prototype.vehicleClass = Car;
 // Our Factory method for creating new Vehicle instances
 VehicleFactory.prototype.createVehicle = function ( options ) {
 
-  if( options.vehicleType === "car" ){
-    this.vehicleClass = Car;
-  }else{
-    this.vehicleClass = Truck;
+  switch(options.vehicleType){
+    case "car":
+      this.vehicleClass = Car;
+      break;
+    case "truck":
+      this.vehicleClass = Truck;
+      break;
+    //defaults to VehicleFactory.prototype.vehicleClass (Car)
   }
 
   return new this.vehicleClass( options );


### PR DESCRIPTION
As written, the code would set a defualt type on the VehicleFactory prototype but _would not ever use it_ because it is overridden in the constructor. This also made switching the default value to Truck in truck factory pointless, as the constructer overrode this as well
