### PR TITLE
Document correct output for testModule.resetCounter()

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -987,7 +987,7 @@ var testModule = (function () {
 testModule.incrementCounter();
 
 // Check the counter value and reset
-// Outputs: 1
+// Outputs: counter value prior to reset: 1
 testModule.resetCounter();
 
 </pre>


### PR DESCRIPTION
Previously the comment stated that testModule.resetCounter() would output 1. While it is true that counter is 1 before the reset, resetCounter outputs "counter value prior to reset: 1" in that example.
