### PR TITLE
Fix typo in "A Publish/Subscribe Implementation"

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -2059,7 +2059,7 @@ var pubsub = {};
     // or listened to
     var topics = {};
 
-    // An topic identifier
+    // A topic identifier
     var subUid = -1;
 
     // Publish or broadcast events of interest


### PR DESCRIPTION
Fix a typo in the example titled "A Publish/Subscribe Implementation".

Before:
![screen shot 2015-10-19 at 2 03 55 pm](https://cloud.githubusercontent.com/assets/13375241/10591388/ca3d2902-766a-11e5-96e0-5c410c32ccf0.png)
After: 
![screen shot 2015-10-19 at 2 04 45 pm](https://cloud.githubusercontent.com/assets/13375241/10591392/cd93728c-766a-11e5-8b86-92ee4f44ed34.png)
