### PR TITLE
fix typo in decorator pattern section

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -3765,7 +3765,7 @@ console.log( decoratedMacbookPro.getPrice() );
 
 <p>In this scenario, a target object can be decorated with new functionality without necessarily breaking or overriding existing methods in the source/superclass object (although this can be done).</p>
 
-<p>In the following example, we define three objects: defaults, options and settings. The aim of the task is to decorate the <code>defaults</code> object with additional functionality found in <code>options</code, which we will make available through <code>settings</code>. We must:</p>
+<p>In the following example, we define three objects: defaults, options and settings. The aim of the task is to decorate the <code>defaults</code> object with additional functionality found in <code>options</code>, which we will make available through <code>settings</code>. We must:</p>
 
 <p>(a) Leave "defaults" in an untouched state where we don't lose the ability to access the properties or functions found in it a later point (b) Gain the ability to use the decorated properties and functions found in "options"</p>
 


### PR DESCRIPTION
The current text reads like this:

"In the following example, we define three objects: defaults, options and settings. The aim of the task is to decorate the `defaults` object with additional functionality found in `optionssettings`."

When it should be:

"In the following example, we define three objects: defaults, options and settings. The aim of the task is to decorate the `defaults` object with additional functionality found in `options`, which we will make available through `settings`."